### PR TITLE
rps in rust

### DIFF
--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,0 +1,2 @@
+/target
+**/*.rs.bk

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1,0 +1,86 @@
+[[package]]
+name = "bitflags"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libc"
+version = "0.2.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rand"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rps-rust"
+version = "0.1.0"
+dependencies = [
+ "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[metadata]
+"checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
+"checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+"checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+"checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
+"checksum rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c"
+"checksum rand_core 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "edecf0f94da5551fc9b492093e30b041a891657db7940ee221f9d2f66e82eef2"
+"checksum winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd"
+"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "rps-rust"
+version = "0.1.0"
+
+# Random is not part of the standard library
+[dependencies]
+rand = "0.5"

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,0 +1,20 @@
+# Rock, Paper, Scissors (Rust)
+
+This is an implementation of a simple rock, paper, scissors app in Rust.
+
+## Installation
+
+If you need help getting Rustup (the recommended way to install Rust), head on over to [https://rustup.rs/](https://rustup.rs/).
+
+## Compilation
+
+No complication is necessary.
+
+## Syntax
+
+This is a command-line application. To play, open up a terminal, navigate to
+the current directory, and run the following command:
+
+```
+cargo run
+```

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,0 +1,66 @@
+extern crate rand;
+
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
+use std::io;
+use std::str::FromStr;
+
+fn main() {
+    use self::Choice::*;
+
+    loop {
+        let computer: Choice = rand::random();
+
+        let player: Choice = loop {
+            let mut input = String::new();
+            println!("Your move: ");
+            io::stdin().read_line(&mut input).unwrap();
+
+            match input.parse() {
+                Ok(s) => break s,
+                Err(_) => println!("Bad move, try again."),
+            }
+        };
+
+        match (&player, &computer) {
+            (Paper, Rock) | (Scissors, Paper) | (Rock, Scissors) => println!("You Win"),
+            _ if player == computer => println!("Tie, Replay!"),
+            _ => println!("Computer Wins!"),
+        };
+    }
+}
+
+#[derive(PartialEq)]
+enum Choice {
+    Rock,
+    Paper,
+    Scissors,
+}
+
+// Choice can be parsed from a String.
+impl FromStr for Choice {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_lowercase().as_str() {
+            "r" | "rock" => Ok(Choice::Rock),
+            "p" | "paper" => Ok(Choice::Paper),
+            "s" | "scissors" => Ok(Choice::Scissors),
+            _ => Err(()),
+        }
+    }
+}
+
+// A random instance of Choice can be created.
+// This can be automated/made simpler with third party libs.
+impl Distribution<Choice> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Choice {
+        match rng.gen_range(0, 3) {
+            0 => Choice::Rock,
+            1 => Choice::Paper,
+            _ => Choice::Scissors,
+        }
+    }
+}


### PR DESCRIPTION
For Rust. Randomization is not part of the standard library.
So I had to use Cargo (Rust package manager) instead of the compiler directly.